### PR TITLE
Support CloudFront custom error response page for 403 HTTP code

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ custom:
   * `name`: (*string*) Name of the S3 Bucket to upload the `distDir` to. Defaults to a generated name.
   * `indexDocument`: (*string*) Defaults to `index.html`.
   * `errorDocument`: (*string*) Defaults to `index.html`.
+  * `forbiddenDocument`: (*string*) Defaults to `index.html`.
 * `distribution`: (*Map*)
   * `dnsName`: (*string* *Required*) A DNS name to use for this Cloudfront distribution. This is required and has no default values.
   * `altDnsName`: (*string*) Another DNS name to use for this Cloudfront distribution.

--- a/index.js
+++ b/index.js
@@ -74,6 +74,7 @@ class ServerlessFrontendPlugin {
     const {
       indexDocument = 'index.html',
       errorDocument = 'index.html',
+      forbiddenDocument = "index.html",
     } = bucket;
 
     const {
@@ -112,6 +113,10 @@ class ServerlessFrontendPlugin {
         {
           ParameterKey: 'ErrorDocument',
           ParameterValue: errorDocument,
+        },
+        {
+          ParameterKey: 'ForbiddenDocument',
+          ParameterValue: forbiddenDocument,
         },
         {
           ParameterKey: 'DnsName',

--- a/templates/aws-cloudfront.json
+++ b/templates/aws-cloudfront.json
@@ -31,6 +31,9 @@
     },
     "ErrorDocument": {
       "Type": "String"
+    },
+    "ForbiddenDocument": {
+      "Type": "String"
     }
   },
 
@@ -59,6 +62,12 @@
       "Fn::Equals": [
         { "Ref": "IndexDocument" },
         { "Ref": "ErrorDocument" }
+      ]
+    },
+    "ForbiddenDocEqualsIndex": {
+      "Fn::Equals": [
+        { "Ref": "IndexDocument" },
+        { "Ref": "ForbiddenDocument" }
       ]
     }
   },
@@ -137,6 +146,18 @@
                   ]
                 },
                 "ResponsePagePath": { "Fn::Sub": "/${ErrorDocument}" }
+              },
+              {
+                "ErrorCode": 403,
+                "ErrorCachingMinTTL": 0,
+                "ResponseCode": {
+                  "Fn::If": [
+                    "ForbiddenDocEqualsIndex",
+                    200,
+                    403
+                  ]
+                },
+                "ResponsePagePath": { "Fn::Sub": "/${ForbiddenDocument}" }
               }
             ],
             "Enabled": true,


### PR DESCRIPTION
Thanks for a great new plugin - works great in our case :+1: 

Here is a suggested improvement that we also use in order to support routing, such as, React Router.