### PR TITLE
Include Cloudfront Security Header Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,24 @@ custom:
   * `command`: (*string*[]) Command and options as an array of strings. For example, `["npm", "start"]` Defaults to `["echo", "no", "frontend", "offline", "command"]`.
   * `env`: (*Map*) A key/value mapping of environment variables and values to inject into the frontend start command.
   * `cwdDir`: (*string*) The directory from which to run the `offline.command`. Defaults to `./frontend` if the directory exists.
+* `securityHeadersConfig`: (*Map*) If provided, security headers will be added via Cloudfront ([AWS Security Header Config Documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-responseheaderspolicy-securityheadersconfig.html)).  You may include the defaults shown below by providing an empty "Map" of the headers you would like to include.  For instance, if you provide an empty *Map* of "contentSecurityPolicy" below, then this plugin will include the defaults shown for "contentSecurityPolicy.contentSecurityPolicy" and "contentSecurityPolicy.override".  If you include only some of the options for a particular security header then the other options will be included with their defaults shown below automatically.  For example, if you include "strictTransportSecurity" and you provide a value to "strictTransportSecurity.accessControlMaxAgeSec" but not the other options under "strictTransportSecurity" - the plugin will assume the defaults for the missing options (includeSubdomains, override and preload will be included for the Strict-Transport-Security header that's generated and all will be set with the defaults shown below). 
+  * `contentSecurityPolicy`: (*Map*) 
+    * `contentSecurityPolicy`: (*String*) Defaults to `"default-src 'self'"`
+    * `override`: (*Boolean*) Defaults to `true`
+  * `frameOptions`: (*Map*)
+    * `frameOption`: (*String*) Defaults to `"SAMEORIGIN"`. One of `"SAMEORIGIN"` or `"DENY"`.
+    * `override`: (*Boolean*) Defaults to `true`
+  * `contentTypeOptions`: (*Map*)
+    * `override`: (*Boolean*) Defaults to `true`
+  * `referrerPolicy`: (*Map*)
+    * `referrerPolicy`: (*String*) Defaults to `"same-origin"`.  One of `"no-referrer"`, `"no-referrer-when-downgrade"`, `"origin"`, `"origin-when-cross-origin"`, `"same-origin"`, `"strict-origin"`, `"strict-origin-when-cross-origin"` or `"unsafe-url"`
+    * `override`: (*Boolean*) Defaults to `true`
+  * `strictTransportSecurity`: (*Map*)
+    * `accessControlMaxAgeSec`: (*String*) Defaults to `"63072000"`
+    * `includeSubdomains`: (*Boolean*) Defaults to `true`
+    * `override`: (*Boolean*) Defaults to `true`
+    * `preload`: (*Boolean*) Defaults to `true`
+
 
 ## Offline Integration
 This plugin seamlessly integrates with [`serverless-offline`](https://www.npmjs.com/package/serverless-offline). Simply Add an `offline` configuration under `custom.serverless-frontend-plugin` in your `serverless.yml`. See `offline` options above.

--- a/README.md
+++ b/README.md
@@ -60,19 +60,19 @@ custom:
   * `command`: (*string*[]) Command and options as an array of strings. For example, `["npm", "start"]` Defaults to `["echo", "no", "frontend", "offline", "command"]`.
   * `env`: (*Map*) A key/value mapping of environment variables and values to inject into the frontend start command.
   * `cwdDir`: (*string*) The directory from which to run the `offline.command`. Defaults to `./frontend` if the directory exists.
-* `securityHeadersConfig`: (*Map*) If provided, security headers will be added via Cloudfront ([AWS Security Header Config Documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-responseheaderspolicy-securityheadersconfig.html)).  You may include the defaults shown below by providing an empty "Map" of the headers you would like to include.  For instance, if you provide an empty *Map* of "contentSecurityPolicy" below, then this plugin will include the defaults shown for "contentSecurityPolicy.contentSecurityPolicy" and "contentSecurityPolicy.override".  If you include only some of the options for a particular security header then the other options will be included with their defaults shown below automatically.  For example, if you include "strictTransportSecurity" and you provide a value to "strictTransportSecurity.accessControlMaxAgeSec" but not the other options under "strictTransportSecurity" - the plugin will assume the defaults for the missing options (includeSubdomains, override and preload will be included for the Strict-Transport-Security header that's generated and all will be set with the defaults shown below). 
-  * `contentSecurityPolicy`: (*Map*) 
+* `securityHeadersConfig`: (*Map*) If provided, security headers will be added via Cloudfront ([AWS Security Headers Config Documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-responseheaderspolicy-securityheadersconfig.html)).  You may include the defaults shown below by providing an empty "Map" of the headers you would like to include.  For instance, if you provide an empty *Map* of "contentSecurityPolicy" below, then this plugin will include the defaults shown for "contentSecurityPolicy.contentSecurityPolicy" and "contentSecurityPolicy.override".  If you include only some of the options for a particular security header then the other options will be included with their defaults shown below automatically.  For example, if you include "strictTransportSecurity" and you provide a value to "strictTransportSecurity.accessControlMaxAgeSec" but not the other options under "strictTransportSecurity" - the plugin will assume the defaults for the missing options (includeSubdomains, override and preload will be included for the Strict-Transport-Security header that's generated and all will be set with the defaults shown below). 
+  * `contentSecurityPolicy`: (*Map*) [Content-Security-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#:~:text=The%20HTTP%20Content%2DSecurity%2DPolicy,server%20origins%20and%20script%20endpoints.)
     * `contentSecurityPolicy`: (*String*) Defaults to `"default-src 'self'"`
     * `override`: (*Boolean*) Defaults to `true`
-  * `frameOptions`: (*Map*)
+  * `frameOptions`: (*Map*) [X-Frame-Options](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options)
     * `frameOption`: (*String*) Defaults to `"SAMEORIGIN"`. One of `"SAMEORIGIN"` or `"DENY"`.
     * `override`: (*Boolean*) Defaults to `true`
-  * `contentTypeOptions`: (*Map*)
+  * `contentTypeOptions`: (*Map*) [X-Content-Type-Options](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options)
     * `override`: (*Boolean*) Defaults to `true`
-  * `referrerPolicy`: (*Map*)
+  * `referrerPolicy`: (*Map*) [Referrer-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy)
     * `referrerPolicy`: (*String*) Defaults to `"same-origin"`.  One of `"no-referrer"`, `"no-referrer-when-downgrade"`, `"origin"`, `"origin-when-cross-origin"`, `"same-origin"`, `"strict-origin"`, `"strict-origin-when-cross-origin"` or `"unsafe-url"`
     * `override`: (*Boolean*) Defaults to `true`
-  * `strictTransportSecurity`: (*Map*)
+  * `strictTransportSecurity`: (*Map*) [Strict-Transport-Security](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security)
     * `accessControlMaxAgeSec`: (*String*) Defaults to `"63072000"`
     * `includeSubdomains`: (*Boolean*) Defaults to `true`
     * `override`: (*Boolean*) Defaults to `true`

--- a/index.js
+++ b/index.js
@@ -115,7 +115,7 @@ class ServerlessFrontendPlugin {
     } = securityHeadersConfig;
 
     /**
-     * Context Security Policy
+     * Content Security Policy
      */
     if ( contentSecurityPolicy ) {
       const {

--- a/index.js
+++ b/index.js
@@ -81,11 +81,11 @@ class ServerlessFrontendPlugin {
 
     const defaultParams = {
       shouldIncludeSecurityHeaders: 'true', // conditionally removes/includes security headers from cloudformation entirely
-      shouldIncludeContentSecurity: 'true', // conditionally removes/includes content security policy headers
-      shouldIncludeStrictTransportSecurity: 'true', // conditionally removes/includes strict transport security headers
-      shouldIncludeContentTypeOptions: 'true', // conditionally removes/includes content type options headers
-      shouldIncludeFrameOptions: 'true', // conditionally removes/includes frame options headers
-      shouldIncludeReferrerPolicy: 'true', // conditionally removes/includes referrer policy headers
+      shouldIncludeContentSecurity: 'true', // conditionally removes/includes Content-Security-Policy header
+      shouldIncludeStrictTransportSecurity: 'true', // conditionally removes/includes Strict-Transport-Security header
+      shouldIncludeContentTypeOptions: 'true', // conditionally removes/includes X-Content-Type-Options header
+      shouldIncludeFrameOptions: 'true', // conditionally removes/includes X-Frame-Options header
+      shouldIncludeReferrerPolicy: 'true', // conditionally removes/includes Referrer-Policy header
       contentSecurityPolicy: `default-src 'self'`,
       contentSecurityPolicyOverride: 'true',
       strictTransportSecurityMaxAge: '63072000',
@@ -124,7 +124,9 @@ class ServerlessFrontendPlugin {
       } = contentSecurityPolicy;
 
       if (userContentSecurityPolicy) defaultParams.contentSecurityPolicy = userContentSecurityPolicy;
-      if ( contentSecurityPolicyOverride === false ) defaultParams.contentSecurityPolicyOverride = contentSecurityPolicyOverride + '';
+      if ( contentSecurityPolicyOverride === false ) {
+        defaultParams.contentSecurityPolicyOverride = contentSecurityPolicyOverride + '';
+      }
     } else {
       if ( contentSecurityPolicy !== null ) {
         defaultParams.shouldIncludeContentSecurity = 'false';
@@ -193,7 +195,9 @@ class ServerlessFrontendPlugin {
 
       if (accessControlMaxAgeSec) defaultParams.strictTransportSecurityMaxAge = accessControlMaxAgeSec;
       if (includeSubdomains === false) defaultParams.strictTransportSecurityIncludeSubdomains = includeSubdomains + '';
-      if (strictTransportSecurityOverride === false) defaultParams.strictTransportSecurityOverride = strictTransportSecurityOverride + '';
+      if (strictTransportSecurityOverride === false) {
+        defaultParams.strictTransportSecurityOverride = strictTransportSecurityOverride + '';
+      }
       if (preload === false) defaultParams.strictTransportSecurityPreload = preload + '';
     } else {
       if ( strictTransportSecurity !== null ) {
@@ -243,15 +247,8 @@ class ServerlessFrontendPlugin {
     const cfClient = this.getCloudFormationClient();
     const bucketName = this.getBucketName();
     const securityHeaderParams = this.generateSecurityHeaderParams();
-
-    console.log('_____________________________________________\n\n');
-
-    console.log(securityHeaderParams);
-
-    console.log('_____________________________________________\n\n');
-
-
     const stackExists = await this.stackExists();
+
     const cfParams = {
       StackName: stackName,
       TemplateBody: JSON.stringify(templates[mode]),

--- a/index.js
+++ b/index.js
@@ -101,7 +101,7 @@ class ServerlessFrontendPlugin {
 
     if (!securityHeadersConfig) {
       return [{
-        ParameterKey: ShouldIncludeSecurityHeaders,
+        ParameterKey: 'ShouldIncludeSecurityHeaders',
         ParameterValue: 'false',
       }];
     }

--- a/index.js
+++ b/index.js
@@ -8,8 +8,10 @@ const { CloudFormation, S3 } = require('aws-sdk');
 const {
   execCmd,
 } = require('./lib/child_process');
+const { capitalizeFirstLetter } = require('./lib/capitalizeFirstLetter');
 
 const templates = require('./templates');
+
 
 class ServerlessFrontendPlugin {
   /**
@@ -70,6 +72,150 @@ class ServerlessFrontendPlugin {
     }
   }
 
+  generateSecurityHeaderParams() {
+    const frontendConfig = this.getConfig();
+    const params = [];
+    const {
+      securityHeadersConfig = null,
+    } = frontendConfig;
+
+    const defaultParams = {
+      shouldIncludeSecurityHeaders: 'true', // conditionally removes/includes security headers from cloudformation entirely
+      shouldIncludeContentSecurity: 'true', // conditionally removes/includes content security policy headers
+      shouldIncludeStrictTransportSecurity: 'true', // conditionally removes/includes strict transport security headers
+      shouldIncludeContentTypeOptions: 'true', // conditionally removes/includes content type options headers
+      shouldIncludeFrameOptions: 'true', // conditionally removes/includes frame options headers
+      shouldIncludeReferrerPolicy: 'true', // conditionally removes/includes referrer policy headers
+      contentSecurityPolicy: `default-src 'self'`,
+      contentSecurityPolicyOverride: 'true',
+      strictTransportSecurityMaxAge: '63072000',
+      strictTransportSecurityIncludeSubdomains: 'true',
+      strictTransportSecurityOverride: 'true',
+      strictTransportSecurityPreload: 'true',
+      contentTypeOptionsOverride: 'true',
+      frameOption: 'SAMEORIGIN',
+      frameOptionOverride: 'true',
+      referrerPolicy: 'same-origin',
+      referrerPolicyOverride: 'true',
+    };
+
+    if (!securityHeadersConfig) {
+      return [{
+        ParameterKey: ShouldIncludeSecurityHeaders,
+        ParameterValue: 'false',
+      }];
+    }
+
+    const {
+      contentSecurityPolicy,
+      contentTypeOptions,
+      frameOptions,
+      referrerPolicy,
+      strictTransportSecurity,
+    } = securityHeadersConfig;
+
+    /**
+     * Context Security Policy
+     */
+    if ( contentSecurityPolicy ) {
+      const {
+        contentSecurityPolicy: userContentSecurityPolicy,
+        override: contentSecurityPolicyOverride,
+      } = contentSecurityPolicy;
+
+      if (userContentSecurityPolicy) defaultParams.contentSecurityPolicy = userContentSecurityPolicy;
+      if ( contentSecurityPolicyOverride === false ) defaultParams.contentSecurityPolicyOverride = contentSecurityPolicyOverride + '';
+    } else {
+      if ( contentSecurityPolicy !== null ) {
+        defaultParams.shouldIncludeContentSecurity = 'false';
+      }
+    }
+
+    /**
+     * Context Type Options
+     */
+    if ( contentTypeOptions ) {
+      const {
+        override: contentTypeOptionsOverride,
+      } = contentTypeOptions;
+
+      if (contentTypeOptionsOverride === false) defaultParams.contentTypeOptionsOverride = contentTypeOptionsOverride + '';
+    } else {
+      if ( contentTypeOptions !== null ) {
+        defaultParams.shouldIncludeContentTypeOptions = 'false';
+      }
+    }
+
+    /**
+     * Frame Options
+     */
+    if (frameOptions) {
+      const {
+        frameOption,
+        override: frameOptionOverride,
+      } = frameOptions;
+
+      if (frameOption) defaultParams.frameOption = frameOption;
+      if (frameOptionOverride === false) defaultParams.frameOptionOverride = frameOptionOverride + '';
+    } else {
+      if (frameOptions !== null) {
+        defaultParams.shouldIncludeFrameOptions = 'false';
+      }
+    }
+
+    /**
+     * Referrer Policy
+     */
+    if (referrerPolicy) {
+      const {
+        referrerPolicy: userReferrerPolicy,
+        override: referrerPolicyOverride,
+      } = referrerPolicy;
+
+      if (userReferrerPolicy) defaultParams.referrerPolicy = userReferrerPolicy;
+      if (referrerPolicyOverride === false) defaultParams.referrerPolicyOverride = referrerPolicyOverride + '';
+    } else {
+      if ( referrerPolicy !== null ) {
+        defaultParams.shouldIncludeReferrerPolicy = 'false';
+      }
+    }
+
+    /**
+     * Strict Transport Security
+     */
+    if (strictTransportSecurity) {
+      const {
+        accessControlMaxAgeSec,
+        includeSubdomains,
+        override: strictTransportSecurityOverride,
+        preload,
+      } = strictTransportSecurity;
+
+      if (accessControlMaxAgeSec) defaultParams.strictTransportSecurityMaxAge = accessControlMaxAgeSec;
+      if (includeSubdomains === false) defaultParams.strictTransportSecurityIncludeSubdomains = includeSubdomains + '';
+      if (strictTransportSecurityOverride === false) defaultParams.strictTransportSecurityOverride = strictTransportSecurityOverride + '';
+      if (preload === false) defaultParams.strictTransportSecurityPreload = preload + '';
+    } else {
+      if ( strictTransportSecurity !== null ) {
+        defaultParams.shouldIncludeStrictTransportSecurity = 'false';
+      }
+    }
+
+    // defaultParams length = 1 implies a user has not included any security headers
+    if (Object.keys(defaultParams).length === 1) {
+      defaultParams.shouldIncludeSecurityHeaders = 'false';
+    }
+
+    Object.keys(defaultParams).forEach((key, index)=>{
+      params.push({
+        ParameterKey: capitalizeFirstLetter(key),
+        ParameterValue: defaultParams[key],
+      });
+    });
+
+    return params;
+  }
+
   async deployClient() {
     const frontendConfig = this.getConfig();
     const {
@@ -96,6 +242,14 @@ class ServerlessFrontendPlugin {
     const stackName = this.getStackName();
     const cfClient = this.getCloudFormationClient();
     const bucketName = this.getBucketName();
+    const securityHeaderParams = this.generateSecurityHeaderParams();
+
+    console.log('_____________________________________________\n\n');
+
+    console.log(securityHeaderParams);
+
+    console.log('_____________________________________________\n\n');
+
 
     const stackExists = await this.stackExists();
     const cfParams = {
@@ -142,6 +296,7 @@ class ServerlessFrontendPlugin {
           ParameterKey: 'HostedZoneName',
           ParameterValue: hostedZoneName || dnsName,
         },
+        ...securityHeaderParams,
       ],
     };
 

--- a/lib/capitalizeFirstLetter.js
+++ b/lib/capitalizeFirstLetter.js
@@ -1,0 +1,10 @@
+function capitalizeFirstLetter(string) {
+  if (typeof string !== 'string') return string;
+  if (string.length < 1) return '';
+  return string.charAt(0).toUpperCase() + string.slice(1);
+}
+
+
+module.exports = {
+  capitalizeFirstLetter,
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "url": "https://github.com/rogersgt"
   },
   "scripts": {
-    "test": "eslint ."
+    "test": "eslint .",
+    "testScripts": "mocha"
   },
   "devDependencies": {
     "aws-sdk": "2.1039.0",

--- a/templates/aws-cloudfront.json
+++ b/templates/aws-cloudfront.json
@@ -90,27 +90,33 @@
     },
     "ShouldIncludeSecurityHeaders": {
       "Type": "String",
-      "AllowedValues" : ["true", "false"]
+      "AllowedValues" : ["true", "false"],
+      "Default": "false"
     },
     "ShouldIncludeContentSecurity": {
       "Type": "String",
-      "AllowedValues" : ["true", "false"]
+      "AllowedValues" : ["true", "false"],
+      "Default": "false"
     },
     "ShouldIncludeStrictTransportSecurity": {
       "Type": "String",
-      "AllowedValues" : ["true", "false"]
+      "AllowedValues" : ["true", "false"],
+      "Default": "false"
     },
     "ShouldIncludeContentTypeOptions": {
       "Type": "String",
-      "AllowedValues" : ["true", "false"]
+      "AllowedValues" : ["true", "false"],
+      "Default": "false"
     },
     "ShouldIncludeFrameOptions": {
       "Type": "String",
-      "AllowedValues" : ["true", "false"]
+      "AllowedValues" : ["true", "false"],
+      "Default": "false"
     },
     "ShouldIncludeReferrerPolicy": {
       "Type": "String",
-      "AllowedValues" : ["true", "false"]
+      "AllowedValues" : ["true", "false"],
+      "Default": "false"
     }
   },
   "Conditions": {

--- a/templates/aws-cloudfront.json
+++ b/templates/aws-cloudfront.json
@@ -34,9 +34,85 @@
     },
     "ForbiddenDocument": {
       "Type": "String"
+    },
+    "ContentSecurityPolicy": {
+      "Type": "String",
+      "Default": "default-src 'self'"
+    },
+    "ContentSecurityPolicyOverride": {
+      "Type": "String",
+      "AllowedValues" : ["true", "false"],
+      "Default": "false"
+    },
+    "StrictTransportSecurityMaxAge": {
+      "Type": "Number",
+      "MinValue": 5,
+      "Default": "63072000"
+    },
+    "StrictTransportSecurityIncludeSubdomains": {
+      "Type": "String",
+      "AllowedValues" : ["true", "false"],
+      "Default": "false"
+    },
+    "StrictTransportSecurityOverride": {
+      "Type": "String",
+      "AllowedValues" : ["true", "false"],
+      "Default": "false"
+    },
+    "StrictTransportSecurityPreload": {
+      "Type": "String",
+      "AllowedValues" : ["true", "false"],
+      "Default": "false"
+    },
+    "ContentTypeOptionsOverride": {
+      "Type": "String",
+      "AllowedValues" : ["true", "false"],
+      "Default": "false"
+    },
+    "FrameOption": {
+      "Type": "String",
+      "AllowedValues" : ["DENY", "SAMEORIGIN"],
+      "Default": "SAMEORIGIN"
+    },
+    "FrameOptionOverride": {
+      "Type": "String",
+      "AllowedValues" : ["true", "false"],
+      "Default": "false"
+    },
+    "ReferrerPolicy": {
+      "Type": "String",
+      "Default": "same-origin"
+    },
+    "ReferrerPolicyOverride": {
+      "Type": "String",
+      "AllowedValues" : ["true", "false"],
+      "Default": "false"
+    },
+    "ShouldIncludeSecurityHeaders": {
+      "Type": "String",
+      "AllowedValues" : ["true", "false"]
+    },
+    "ShouldIncludeContentSecurity": {
+      "Type": "String",
+      "AllowedValues" : ["true", "false"]
+    },
+    "ShouldIncludeStrictTransportSecurity": {
+      "Type": "String",
+      "AllowedValues" : ["true", "false"]
+    },
+    "ShouldIncludeContentTypeOptions": {
+      "Type": "String",
+      "AllowedValues" : ["true", "false"]
+    },
+    "ShouldIncludeFrameOptions": {
+      "Type": "String",
+      "AllowedValues" : ["true", "false"]
+    },
+    "ShouldIncludeReferrerPolicy": {
+      "Type": "String",
+      "AllowedValues" : ["true", "false"]
     }
   },
-
   "Conditions": {
     "CreateAltDnsName": {
       "Fn::Not": [
@@ -46,6 +122,54 @@
             ""
           ]
         }
+      ]
+    },
+    "CreateSecurityHeaders": {
+      "Fn::Equals": [
+        {
+            "Ref": "ShouldIncludeSecurityHeaders"
+        },
+        "true"
+      ]
+    },
+    "IncludeContentSecurity": {
+      "Fn::Equals": [
+        {
+            "Ref": "ShouldIncludeContentSecurity"
+        },
+        "true"
+      ]
+    },
+    "IncludeStrictTransportSecurity": {
+      "Fn::Equals": [
+        {
+            "Ref": "ShouldIncludeStrictTransportSecurity"
+        },
+        "true"
+      ]
+    },
+    "IncludeContentTypeOptions": {
+      "Fn::Equals": [
+        {
+            "Ref": "ShouldIncludeContentTypeOptions"
+        },
+        "true"
+      ]
+    },
+    "IncludeFrameOptions": {
+      "Fn::Equals": [
+        {
+            "Ref": "ShouldIncludeFrameOptions"
+        },
+        "true"
+      ]
+    },
+    "IncludeReferrerPolicy": {
+      "Fn::Equals": [
+        {
+            "Ref": "ShouldIncludeReferrerPolicy"
+        },
+        "true"
       ]
     },
     "UseStage": {
@@ -71,7 +195,6 @@
       ]
     }
   },
-
   "Resources": {
     "FrontendBucket": {
       "Type": "AWS::S3::Bucket",
@@ -106,6 +229,103 @@
               }
             }
           ]
+        }
+      }
+    },
+    "ResponseHeadersPolicy": {
+      "Type" : "AWS::CloudFront::ResponseHeadersPolicy",
+      "Condition": "CreateSecurityHeaders",
+      "Properties" : {
+        "ResponseHeadersPolicyConfig": {
+          "Name": {
+            "Fn::Sub": [
+              "${ServiceName}-${Stage}-ResponseHeadersPolicy",
+              {
+                "ServiceName": {
+                  "Ref": "ServiceName"
+                },
+                "Stage": {
+                  "Ref": "Stage"
+                }
+              }
+              
+            ]
+          }, 
+          "SecurityHeadersConfig" : {
+            "ContentSecurityPolicy": {
+              "Fn::If" : [
+                "IncludeContentSecurity",
+                {
+                  "ContentSecurityPolicy": {
+                    "Ref": "ContentSecurityPolicy"
+                  },
+                  "Override": {
+                    "Ref": "ContentSecurityPolicyOverride"
+                  }
+                },
+                {"Ref" : "AWS::NoValue"}
+              ]
+            },
+            "StrictTransportSecurity": {
+              "Fn::If" : [
+                "IncludeStrictTransportSecurity",
+                {
+                  "AccessControlMaxAgeSec": {
+                    "Ref": "StrictTransportSecurityMaxAge"
+                  },
+                  "IncludeSubdomains": {
+                    "Ref": "StrictTransportSecurityIncludeSubdomains"
+                  },
+                  "Override": {
+                    "Ref": "StrictTransportSecurityOverride"
+                  },
+                  "Preload": {
+                    "Ref": "StrictTransportSecurityPreload"
+                  }
+                },
+                {"Ref" : "AWS::NoValue"}
+              ]
+            },
+            "ContentTypeOptions": {
+              "Fn::If" : [
+                "IncludeContentTypeOptions",
+                {
+                  "Override": {
+                    "Ref": "ContentTypeOptionsOverride"
+                  }
+                },
+                {"Ref" : "AWS::NoValue"}
+              ]
+            },
+            "FrameOptions": {
+              "Fn::If" : [
+                "IncludeFrameOptions",
+                {
+                  "FrameOption": {
+                    "Ref": "FrameOption"
+                  },
+                  "Override": {
+                    "Ref": "FrameOptionOverride"
+                  }
+                },
+                {"Ref" : "AWS::NoValue"}
+              ]
+            },
+            "ReferrerPolicy": {
+              "Fn::If" : [
+                "IncludeReferrerPolicy",
+                {
+                  "ReferrerPolicy": {
+                    "Ref": "ReferrerPolicy"
+                  },
+                  "Override": {
+                    "Ref": "ReferrerPolicyOverride"
+                  }
+                },
+                {"Ref" : "AWS::NoValue"}
+              ]
+            }
+          }
         }
       }
     },
@@ -185,7 +405,14 @@
                 "QueryString" : false,
                 "Cookies" : { "Forward" : "none" }
               },
-              "ViewerProtocolPolicy" : "redirect-to-https"
+              "ViewerProtocolPolicy" : "redirect-to-https",
+              "ResponseHeadersPolicyId" : {
+                "Fn::If" : [
+                  "CreateSecurityHeaders",
+                  {"Ref": "ResponseHeadersPolicy"},
+                  {"Ref" : "AWS::NoValue"}
+                ]
+              }
             }
           },
           "Tags" : [

--- a/test/capitalizeFirstLetter.test.js
+++ b/test/capitalizeFirstLetter.test.js
@@ -1,0 +1,23 @@
+const { capitalizeFirstLetter } = require('../lib/capitalizeFirstLetter');
+const { expect } = require('chai');
+
+
+describe('capitalizeFirstLetter.js', function() {
+  it('should capitalize first letter of a valid string', function() {
+    const mockString = 'some string';
+    const expectedResponseMock = 'Some string';
+
+    const value = capitalizeFirstLetter(mockString);
+    expect(value).to.be.equal(expectedResponseMock);
+  });
+
+  it('should return parameter if non-string param is passed', function() {
+    const value = capitalizeFirstLetter(34);
+    expect(value).to.be.equal(34);
+  });
+
+  it('should return an empty string if invalid string passed', function() {
+    const value = capitalizeFirstLetter('');
+    expect(value).to.be.equal('');
+  });
+});


### PR DESCRIPTION
Have a current need to include security headers for this implementation ([Main AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-responseheaderspolicy-securityheadersconfig.html)).  This adds the provided security headers to the Cloudfront distribution.  Example yml of the options available (the readme includes an overview).

```yaml
serverless-frontend-plugin:
    securityHeadersConfig: 
      contentSecurityPolicy: 
        contentSecurityPolicy: "default-src 'self'"
        override: true
      frameOptions:
        frameOption: "DENY"
        override: true
      contentTypeOptions: 
        override: true
      referrerPolicy:
        referrerPolicy: 'origin-when-cross-origin'
        override: false
      strictTransportSecurity: 
        accessControlMaxAgeSec: '63072000'
        includeSubdomains: true
        override: true
        preload: true
```

From this:

![image](https://user-images.githubusercontent.com/97993274/210015792-0f7c360d-f456-4825-a411-f374152bc576.png)

to:

![image](https://user-images.githubusercontent.com/97993274/210015805-1c71703f-c1bc-42e0-9eb4-0aaad31aabe1.png)


